### PR TITLE
Update readme for Photoshop issue I ran into running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This prototype runs as 3 independent modules:
 ### 1 - Configure Photoshop
 
 - Go to "Preferences > Plug-ins", enable "Remote Connection" and set a friendly password that you'll need later.
+- Make sure that your PS document settings match those in ```server/src/ps.py```, otherwise only an empty layer will be pasted.
 
 <!--
 ### 2) Setup the local server


### PR DESCRIPTION
If you don't change the settings in `ps.py` to match the document you want to paste into, it will only paste an empty layer. This was brought up in a Github issue but figured I'd add it to the readme since it flummoxed me for a good bit. 

Running on OSX Mojave 10.14.1 and iPhone 6S