### PR TITLE
Automatically get document width and height

### DIFF
--- a/server/src/ps.py
+++ b/server/src/ps.py
@@ -1,13 +1,5 @@
 from photoshop import PhotoshopConnection
 
-# TODO: This offset should be detected by getTopLeft() but the new version
-# of Photoshop doesn't seem to support executeActionGet so we put it
-# manually here in the meantime.
-SCREEN_PIXELS_DENSITY = 2
-DOC_OFFSET_X = 74 * SCREEN_PIXELS_DENSITY
-DOC_OFFSET_Y = 130 * SCREEN_PIXELS_DENSITY
-DOC_WIDTH = 2121
-DOC_HEIGHT = 1280
 
 def paste(filename, name, x, y, password='123456'):
 
@@ -16,6 +8,8 @@ def paste(filename, name, x, y, password='123456'):
         function pasteImage(filename, layerName, x, y) {
             var fileRef = new File(filename);
             var doc = app.activeDocument;
+
+            app.preferences.rulerUnits = Units.PIXELS;
             
             var currentLayer = doc.artLayers.add();
             var curr_file = app.open(fileRef);
@@ -25,7 +19,15 @@ def paste(filename, name, x, y, password='123456'):
 
             doc.paste();
             doc.activeLayer.name = layerName;
-            doc.activeLayer.translate(x, y);
+
+            var doc_x = Number(doc.width);
+            var doc_y = Number(doc.height);
+            
+            // Some magic numbers in here, but works well
+            var new_x = x - ((doc_x * 0.5) + (74 * 2));
+            var new_y = y - ((doc_y * 0.5) + (130 * 2));
+
+            doc.activeLayer.translate(new_x, new_y);
             try {
                 doc.activeLayer.move(doc.layers[doc.layers.length - 1], ElementPlacement.PLACEBEFORE);
             } catch(e) {
@@ -45,7 +47,5 @@ def paste(filename, name, x, y, password='123456'):
             }
         }
         """
-        x -= DOC_WIDTH * 0.5 + DOC_OFFSET_X
-        y -= DOC_HEIGHT * 0.5 + DOC_OFFSET_Y
         script += f'pasteImage("{filename}", "{name}", {x}, {y})'
         conn.execute(script)


### PR DESCRIPTION
This will automatically get the activeDocument width and height from within the photoshop script, so you no longer need to manual adjust it in the `ps.py` file

I found that using the actual provided DPI from `doc.resolution` did not work so for now I kept the density at 2 (Not sure how that number was derived to begin with). So these numbers may have to be tweaked a bit or set to be configured (rather than just hardcoded), but this worked very well on my setup at any arbitrary width, height, and resolution. Can drag and drop into new files with no changes or adjustments needed