### PR TITLE
Fix typo in requirements

### DIFF
--- a/server/requirements-clipboard-macos.txt
+++ b/server/requirements-clipboard-macos.txt
@@ -1,3 +1,3 @@
 pasteboard==0.3.1
-PyAutoGUI==0.9.50pip
+PyAutoGUI==0.9.50
 osascript==2019.4.13


### PR DESCRIPTION
There's a typo which caused an error when performing pip install