### PR TITLE
Fix: app gets into invalidate state after copy

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -82,12 +82,10 @@ export default function App() {
     const { uri } = await ImageManipulator.manipulateAsync(
       photo.uri,
       [
-        { resize: { width: 256, height: 512 } },
-        { crop: { originX: 0, originY: 128, width: 256, height: 256 } },
-        // { resize: { width: 256, height: 457 } },
-        // { crop: { originX: 0, originY: 99, width: 256, height: 256 } },
-        // { resize: { width: 256, height: 341 } },
-        // { crop: { originX: 0, originY: 42, width: 256, height: 256 } },
+        { resize: { width: 512, height: 1024 } },
+        { crop: { originX: 0, originY: 256, width: 512, height: 512 } },
+        // { resize: { width: 256, height: 512 } },
+        // { crop: { originX: 0, originY: 128, width: 256, height: 256 } },
       ]
       // { compress: 0, format: ImageManipulator.SaveFormat.JPEG, base64: false }
     );

--- a/server/requirements-clipboard-macos.txt
+++ b/server/requirements-clipboard-macos.txt
@@ -1,3 +1,3 @@
 pasteboard==0.3.1
-PyAutoGUI==0.9.50pip
+PyAutoGUI==0.9.50
 osascript==2019.4.13

--- a/server/requirements-clipboard-macos.txt
+++ b/server/requirements-clipboard-macos.txt
@@ -1,0 +1,3 @@
+pasteboard==0.3.1
+PyAutoGUI==0.9.50pip
+osascript==2019.4.13

--- a/server/src/get_active_window.scpt
+++ b/server/src/get_active_window.scpt
@@ -1,0 +1,16 @@
+# by @timpulver https://gist.github.com/timpulver/4753750
+
+global frontApp, frontAppName, windowTitle
+
+set windowTitle to ""
+tell application "System Events"
+    set frontApp to first application process whose frontmost is true
+    set frontAppName to name of frontApp
+    tell process frontAppName
+        tell (1st window whose value of attribute "AXMain" is true)
+            set windowTitle to value of attribute "AXTitle"
+        end tell
+    end tell
+end tell
+
+return {frontAppName, windowTitle}

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -165,9 +165,11 @@ def paste():
         logging.info(' > sending to photoshop...')
         name = datetime.today().strftime('%Y-%m-%d-%H:%M:%S')
         img_path = os.path.join(os.getcwd(), 'cut_current.png')
-        if not ps.paste(img_path, name, x, y, password=args.photoshop_password):
-            logging.error('Something went wrong with the photoshop script execution')
-            return
+        err = ps.paste(img_path, name, x, y, password=args.photoshop_password)
+        if err is not None:
+            logging.error('error sending to photoshop')
+            logging.error(err)
+            jsonify({'status': 'error sending to photoshop'})
     else:
         logging.info('screen not found')
 

--- a/server/src/ps.py
+++ b/server/src/ps.py
@@ -1,5 +1,5 @@
 from photoshop import PhotoshopConnection
-from os.path import basename
+from os.path import dirname, basename
 
 # TODO: This offset should be detected by getTopLeft() but the new version
 # of Photoshop doesn't seem to support executeActionGet so we put it
@@ -17,10 +17,13 @@ def paste(filename, name, x, y, password='123456'):
     filename = filename.replace('\\', '/')
 
     with PhotoshopConnection(password=password) as conn:
-        script = open(basename(__file__) + '/script.js', 'r').read()
+        script = open(basename(dirname(__file__)) + '/script.js', 'r').read()
         x -= DOC_WIDTH * 0.5 + DOC_OFFSET_X
         y -= DOC_HEIGHT * 0.5 + DOC_OFFSET_Y
         script += f'pasteImage("{filename}", "{name}", {x}, {y})'
         result = conn.execute(script)
-        if result.status != 0:
-            return False
+        print(result)
+        if result['status'] != 0:
+            return result
+    
+    return None


### PR DESCRIPTION
Users reported bugs #41, #45 where they were able to copy but not
paste. This is basically a user experience issue where the user didn't
know they had to hold the finger until the copy operation is complete.

However, once a user takes a picture and lift her finger while
the cut command has not completed from the server, the app gets into a state
where it's not recoverable.

The fix proposed uses a single variable "appState" of type AppState to maintain
the app's state. AppState type can be one of:

```
Init - start up of app
CopyReady - app is ready to copy
PasteReady - app is ready to paste
Busy - app is waiting for results
```
State variable "pressed" and "pasting" have both been removed.

The fix **significantly changes the user experience** where it's tap to copy
and then tap to paste.

If we'd like to go back to the hold-then-release UX, we'd need to
discuss on how the UX can be more intuitive.

Fixes #41, #45
