### PR TITLE
Fixes issues #39(Error 'atob' failed)

### DIFF
--- a/app/components/Base64.tsx
+++ b/app/components/Base64.tsx
@@ -56,7 +56,7 @@ FileReader.prototype.readAsArrayBuffer = function (blob) {
   const fr = new FileReader();
   fr.onloadend = () => {
     const content = Base64.atob(
-      fr.result.substr("data:application/octet-stream;base64,".length)
+      fr.result.substr(fr.result.indexOf(',') + 1)
     );
     const buffer = new ArrayBuffer(content.length);
     const view = new Uint8Array(buffer);


### PR DESCRIPTION
Sometimes file's header is not [data:application/octet-stream;base64,],
so use ',' to split the string.

Fixes #39